### PR TITLE
Fixed destination path to views folder

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -48,7 +48,7 @@ module.exports = yeoman.generators.Base.extend({
       this.fs.copyTpl(
         this.templatePath('_server.js'),
         this.destinationPath('server.js'),
-        this.destinationPath('/views/index.ejs'), {
+        this.destinationPath('views/index.ejs'), {
           name: this.props.name
         }
       );
@@ -66,7 +66,7 @@ module.exports = yeoman.generators.Base.extend({
       // Views
       this.fs.copyTpl(
         this.templatePath('_views/_index.ejs'),
-        this.destinationPath('/views/index.ejs'), {
+        this.destinationPath('views/index.ejs'), {
           name: this.props.name
         }
       );


### PR DESCRIPTION
Without this fix, I was getting the following error

==> yo mygenerator
? Your project name testbed
testbed
   create bower.json
   create package.json
identical .bowerrc
   create server.js
   create routes/all.js
   create model/todo.js
   create ../../../../../../../views/index.ejs
<path-to>/node_modules/mkdirp/index.js:90
                    throw err0;
                    ^

Error: EACCES: permission denied, mkdir '/views'
    at Error (native)
    at Object.fs.mkdirSync (fs.js:794:18)
    at Function.sync (<path-to>/node_modules/mkdirp/index.js:71:13)
    at write (<path-to>/node_modules/mem-fs-editor/actions/commit.js:12:12)
    at DestroyableTransform._transform (<path-to>/node_modules/mem-fs-editor/actions/commit.js:43:7)
    at DestroyableTransform.Transform._read (<path-to>/node_modules/readable-stream/lib/_stream_transform.js:172:10)
    at DestroyableTransform.Transform._write (<path-to>/node_modules/readable-stream/lib/_stream_transform.js:160:12)
    at doWrite (<path-to>/node_modules/readable-stream/lib/_stream_writable.js:335:12)
    at writeOrBuffer (<path-to>/node_modules/readable-stream/lib/_stream_writable.js:321:5)
    at DestroyableTransform.Writable.write (<path-to>/node_modules/readable-stream/lib/_stream_writable.js:248:11)